### PR TITLE
91 update 타운 복귀 bull queue 적용

### DIFF
--- a/src/bull/player/consumers/enter-town.consumers.js
+++ b/src/bull/player/consumers/enter-town.consumers.js
@@ -1,0 +1,9 @@
+import Bull from 'bull';
+import { ENTER_TOWN_JOB_NAME, ENTER_TOWN_QUEUE_NAME } from '../../../constants/constants.js';
+import EnterTownProcessor from '../processors/enter-town.processor.js';
+
+const enterTownQueue = new Bull(ENTER_TOWN_QUEUE_NAME);
+
+export const setEnterTownQueue = () => {
+  enterTownQueue.process(ENTER_TOWN_JOB_NAME, EnterTownProcessor);
+};

--- a/src/bull/player/enter-town.js
+++ b/src/bull/player/enter-town.js
@@ -1,0 +1,10 @@
+import Bull from 'bull';
+import { ENTER_TOWN_JOB_NAME, ENTER_TOWN_QUEUE_NAME } from '../../constants/constants.js';
+import { setEnterTownQueue } from './consumers/enter-town.consumers.js';
+
+const enterTownQueue = new Bull(ENTER_TOWN_QUEUE_NAME);
+setEnterTownQueue();
+
+export const enqueueEnterTownJob = (data) => {
+  enterTownQueue.add(ENTER_TOWN_JOB_NAME, data);
+};

--- a/src/bull/player/processors/enter-town.processor.js
+++ b/src/bull/player/processors/enter-town.processor.js
@@ -1,0 +1,16 @@
+import { addTownSession, getAllTownSessions } from '../../../session/town.session.js';
+import { getUserById } from '../../../session/user.session.js';
+
+const EnterTownProcessor = (job, done) => {
+  const { accountId } = job.data;
+  const user = getUserById(accountId);
+  const townSessions = getAllTownSessions();
+  let townSession = townSessions.find((townSession) => !townSession.isFull());
+  if (!townSession) {
+    townSession = addTownSession();
+  }
+  townSession.addUser(user);
+  done();
+};
+
+export default EnterTownProcessor;

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -18,3 +18,7 @@ export const isBlackListed = (payloadType) => loggerBlackListSet.has(payloadType
 // ------- MONSTER KILL ---------
 export const MONSTER_HIT_QUEUE_NAME = 'monster-hit-queue';
 export const MONSTER_HIT_JOB_NAME = 'monster-hit-job';
+
+// ------- ENTER TOWN ---------
+export const ENTER_TOWN_QUEUE_NAME = 'enter-town-queue';
+export const ENTER_TOWN_JOB_NAME = 'enter-town-job';

--- a/src/handlers/dungeon/monster-move.handler.js
+++ b/src/handlers/dungeon/monster-move.handler.js
@@ -7,11 +7,9 @@ const monsterMoveHandler = async ({ socket, accountId, packet }) => {
   const { monsterIdx, transform } = packet;
   const dungeonSession = getDungeonSessionByUserId(accountId);
 
-  if (!dungeonSession) {
-    throw new CustomError(ErrorCodes.GAME_NOT_FOUND, '던전 세션을 찾을 수 없습니다.');
+  if (dungeonSession) {
+    dungeonSession.moveMonster(accountId, monsterIdx, transform);
   }
-
-  dungeonSession.moveMonster(accountId, monsterIdx, transform);
 };
 
 export default monsterMoveHandler;


### PR DESCRIPTION
### 버그 확인

- 4명의 플레이어가 게임 종료 후, 타운 복귀 시 간헐적으로 다른 캐릭터가 안보이는 버그
- 타운 복귀 후 채팅 메시지 기능 전송 오류

### 원인

- 게임 종료 후, C_Enter 패킷을 4명의 플레이어가 동시에 보내게 되어 기존 유저를 찾아 타운 세션에 넣는 로직에 동시성 문제 발생

### 해결 방안

- 타운 복귀에 Bull Queue 적용

### 관련 이미지

![image](https://github.com/user-attachments/assets/98765728-8ff4-463c-ac4e-cd0dea7b896a)
